### PR TITLE
fix(flower grid): update grid CSS for improved UX across screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,10 @@
         </div>
 
         <!-- Grid -->
-        <div class="grid" id="flower-grid"></div>
+         <div class="grid-container">
+            <div class="grid" id="flower-grid"></div>
+         </div>
+        
     </div>
     <div class="container">
     <img src="assets/invisibletext.png" alt="invisibletext" class="title-image">

--- a/styles.css
+++ b/styles.css
@@ -548,7 +548,6 @@ body, html {
 
 
 /* GRID STUFF */
-
 .grid-container {
     padding: 0 20px 50px; /* Add padding to prevent content from touching the edges */
     display: flex;
@@ -582,6 +581,7 @@ body, html {
     }
 }
 
+/* GRID BOXES */
 .grid div {
     width: 50px;
     height: 50px;
@@ -777,9 +777,7 @@ body, html {
         /* Removed position: absolute; */
         /* Removed top, left, and transform properties */
         /* Use position: relative; if you still need to position elements within the container */
-        /* align-items: center; */
-        /* justify-content: center; */
-        overflow-x: scroll;
+        align-items: center;
     }
     
     .title-image {

--- a/styles.css
+++ b/styles.css
@@ -560,6 +560,21 @@ body, html {
     margin: 0 auto;
     margin-top: 20px; /* Add margin to separate grid from buttons */
     justify-content: center;
+
+    @media (max-width: 450px){
+        display: grid;
+        grid-template-columns: repeat(10, 1fr);
+        grid-template-rows: repeat(10, 1fr);
+        gap: 5px;
+        column-gap: 2px;
+        width: auto;
+        max-width: 90%; /* Optional: adjust to control maximum width */
+        margin: 0 auto; /* Ensures the grid stays centered */
+        padding-left: 30px; /* Adjust as needed */
+        padding-right: 30px; /* Adjust as needed */
+        box-sizing: border-box; /* Includes padding within the grid's width */
+
+    }
 }
 
 .grid div {
@@ -577,7 +592,36 @@ body, html {
     word-wrap: break-word;
     transition: transform 0.2s ease; /* Smooth scaling transition */
     border-radius: 10px; /* Add rounded corners */
+
+    @media (max-width: 450px){
+        width: 30px;
+        height: 30px;
+
+        font-size: 5px; /* Adjusted font size */
+        
+    }
 }
+
+/* IDK THIS KINDA WORKS BUT really DOESN'T SO KEEP ABOVE CODE FOR NOW */
+ /*   .grid {
+        display: grid;
+        grid-template-columns: repeat(10, 1fr);
+        grid-template-rows: repeat(10, 1fr);
+        gap: 2px;
+        width: 100%; /* Make the grid container fill the available width */
+ /*       max-width: 100%; /* Keep the grid within 90% of the viewport width */
+ /*       margin: 0 auto; /* Center the grid horizontally */
+ /*       aspect-ratio: 1 / 1; /* Maintain a square aspect ratio for the grid */
+ /*       padding: 0px 0px; /* Optional: Add horizontal padding */
+ /*       box-sizing: border-box; /* Includes padding and border in the width calculation */
+ /*   }
+    
+    .grid div {
+        width: 100%; /* Make each cell automatically resize based on the container */
+ /*       height: auto; /* Maintain proportional height */
+ /*       aspect-ratio: 1 / 1; /* Ensure square cells */
+ /*       font-size: 5px; /* Adjusted font size */
+ /*   } */
 
 .grid div:hover {
     transform: scale(1.2); /* Scale the square on hover */
@@ -743,49 +787,6 @@ body, html {
         
        
     }
-
-    .grid {
-        display: grid;
-        grid-template-columns: repeat(10, 1fr);
-        grid-template-rows: repeat(10, 1fr);
-        gap: 5px;
-        column-gap: 2px;
-        width: auto;
-        max-width: 90%; /* Optional: adjust to control maximum width */
-        margin: 0 auto; /* Ensures the grid stays centered */
-        padding-left: 30px; /* Adjust as needed */
-        padding-right: 30px; /* Adjust as needed */
-        box-sizing: border-box; /* Includes padding within the grid's width */
-    }
-
-    .grid div {
-        width: 30px;
-        height: 30px;
-
-        font-size: 5px; /* Adjusted font size */
-    }
-
-/* IDK THIS KINDA WORKS BUT really DOESN'T SO KEEP ABOVE CODE FOR NOW */
- /*   .grid {
-        display: grid;
-        grid-template-columns: repeat(10, 1fr);
-        grid-template-rows: repeat(10, 1fr);
-        gap: 2px;
-        width: 100%; /* Make the grid container fill the available width */
- /*       max-width: 100%; /* Keep the grid within 90% of the viewport width */
- /*       margin: 0 auto; /* Center the grid horizontally */
- /*       aspect-ratio: 1 / 1; /* Maintain a square aspect ratio for the grid */
- /*       padding: 0px 0px; /* Optional: Add horizontal padding */
- /*       box-sizing: border-box; /* Includes padding and border in the width calculation */
- /*   }
-    
-    .grid div {
-        width: 100%; /* Make each cell automatically resize based on the container */
- /*       height: auto; /* Maintain proportional height */
- /*       aspect-ratio: 1 / 1; /* Ensure square cells */
- /*       font-size: 5px; /* Adjusted font size */
- /*   } */
-
 
     .container {
         text-align: center;

--- a/styles.css
+++ b/styles.css
@@ -550,14 +550,14 @@ body, html {
 /* GRID STUFF */
 
 .grid-container {
-    overflow-x: scroll; /* Allow horizontal scrolling */
-    padding: 0 20px; /* Add padding to prevent content from touching the edges */
+    /* overflow-x: scroll; Allow horizontal scrolling */
+    padding: 0 20px 50px; /* Add padding to prevent content from touching the edges */
     display: flex;
     /* align-items: center; */
     justify-content: center;
     position: absolute;
     min-width: 98%;
-
+    
     @media (max-width: 450px){
         display: block;
     }
@@ -573,6 +573,7 @@ body, html {
     width: 600px; /* Set a fixed width for larger screens */
     /* margin: 0 auto; */
     margin-top: 20px; /* Add margin to separate grid from buttons */
+    overflow: scroll;
     /* justify-content: center; */
     
     @media (max-width: 450px) {
@@ -581,7 +582,7 @@ body, html {
         gap: 5px;
         column-gap: 2px;
         width: 100%; /* Use full width for small screens */
-        max-width: none; /* Remove max-width restriction */
+        /* max-width: none; */ /* Remove max-width restriction */
         box-sizing: border-box;
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -550,13 +550,11 @@ body, html {
 /* GRID STUFF */
 
 .grid-container {
-    /* overflow-x: scroll; Allow horizontal scrolling */
     padding: 0 20px 50px; /* Add padding to prevent content from touching the edges */
     display: flex;
-    /* align-items: center; */
     justify-content: center;
     position: absolute;
-    min-width: 98%;
+    width: calc(100vw - 40px);
     
     @media (max-width: 450px){
         display: block;
@@ -570,11 +568,9 @@ body, html {
     gap: 5px;
     column-gap: 2px;
     max-width: 100% !important; /* Use full width to allow centering */
-    width: 600px; /* Set a fixed width for larger screens */
-    /* margin: 0 auto; */
+    width: 600px;
     margin-top: 20px; /* Add margin to separate grid from buttons */
     overflow: scroll;
-    /* justify-content: center; */
     
     @media (max-width: 450px) {
         grid-template-columns: repeat(10, 1fr);
@@ -582,7 +578,6 @@ body, html {
         gap: 5px;
         column-gap: 2px;
         width: 100%; /* Use full width for small screens */
-        /* max-width: none; */ /* Remove max-width restriction */
         box-sizing: border-box;
     }
 }
@@ -649,7 +644,6 @@ body, html {
     .setting-button {
         width: 30px;
     }
-
 
     .popup-button {
 

--- a/styles.css
+++ b/styles.css
@@ -549,31 +549,36 @@ body, html {
 
 /* GRID STUFF */
 
+.grid-container {
+    overflow-x: scroll; /* Allow horizontal scrolling */
+    padding: 0 20px; /* Add padding to prevent content from touching the edges */
+    display: flex;
+    /* align-items: center; */
+    justify-content: center;
+    position: absolute;
+    min-width: 95%;
+}
+
 .grid {
     display: grid;
     grid-template-columns: repeat(10, 1fr);
     grid-template-rows: repeat(10, 1fr);
     gap: 5px;
     column-gap: 2px;
-    max-width: 600px; 
-    width: auto;
-    margin: 0 auto;
+    max-width: 100%; /* Use full width to allow centering */
+    /* width: 600px; */ /* Set a fixed width for larger screens */
+    /* margin: 0 auto; */
     margin-top: 20px; /* Add margin to separate grid from buttons */
-    justify-content: center;
+    /* justify-content: center; */
 
-    @media (max-width: 450px){
-        display: grid;
+    @media (max-width: 450px) {
         grid-template-columns: repeat(10, 1fr);
         grid-template-rows: repeat(10, 1fr);
         gap: 5px;
         column-gap: 2px;
-        width: auto;
-        max-width: 90%; /* Optional: adjust to control maximum width */
-        margin: 0 auto; /* Ensures the grid stays centered */
-        padding-left: 30px; /* Adjust as needed */
-        padding-right: 30px; /* Adjust as needed */
-        box-sizing: border-box; /* Includes padding within the grid's width */
-
+        width: 100%; /* Use full width for small screens */
+        max-width: none; /* Remove max-width restriction */
+        box-sizing: border-box;
     }
 }
 
@@ -593,35 +598,12 @@ body, html {
     transition: transform 0.2s ease; /* Smooth scaling transition */
     border-radius: 10px; /* Add rounded corners */
 
-    @media (max-width: 450px){
+    @media (max-width: 450px) {
         width: 30px;
         height: 30px;
-
         font-size: 5px; /* Adjusted font size */
-        
     }
 }
-
-/* IDK THIS KINDA WORKS BUT really DOESN'T SO KEEP ABOVE CODE FOR NOW */
- /*   .grid {
-        display: grid;
-        grid-template-columns: repeat(10, 1fr);
-        grid-template-rows: repeat(10, 1fr);
-        gap: 2px;
-        width: 100%; /* Make the grid container fill the available width */
- /*       max-width: 100%; /* Keep the grid within 90% of the viewport width */
- /*       margin: 0 auto; /* Center the grid horizontally */
- /*       aspect-ratio: 1 / 1; /* Maintain a square aspect ratio for the grid */
- /*       padding: 0px 0px; /* Optional: Add horizontal padding */
- /*       box-sizing: border-box; /* Includes padding and border in the width calculation */
- /*   }
-    
-    .grid div {
-        width: 100%; /* Make each cell automatically resize based on the container */
- /*       height: auto; /* Maintain proportional height */
- /*       aspect-ratio: 1 / 1; /* Ensure square cells */
- /*       font-size: 5px; /* Adjusted font size */
- /*   } */
 
 .grid div:hover {
     transform: scale(1.2); /* Scale the square on hover */

--- a/styles.css
+++ b/styles.css
@@ -566,8 +566,8 @@ body, html {
     grid-template-rows: repeat(10, 1fr);
     gap: 5px;
     column-gap: 2px;
-    max-width: 100% !important; /* Use full width to allow centering */
-    width: 600px;
+    max-width: -webkit-fill-available !important; /* Use full width to allow centering */
+    width: fit-content;
     margin-top: 20px; /* Add margin to separate grid from buttons */
     overflow: scroll;
     

--- a/styles.css
+++ b/styles.css
@@ -556,7 +556,11 @@ body, html {
     /* align-items: center; */
     justify-content: center;
     position: absolute;
-    min-width: 95%;
+    min-width: 98%;
+
+    @media (max-width: 450px){
+        display: block;
+    }
 }
 
 .grid {
@@ -565,12 +569,12 @@ body, html {
     grid-template-rows: repeat(10, 1fr);
     gap: 5px;
     column-gap: 2px;
-    max-width: 100%; /* Use full width to allow centering */
-    /* width: 600px; */ /* Set a fixed width for larger screens */
+    max-width: 100% !important; /* Use full width to allow centering */
+    width: 600px; /* Set a fixed width for larger screens */
     /* margin: 0 auto; */
     margin-top: 20px; /* Add margin to separate grid from buttons */
     /* justify-content: center; */
-
+    
     @media (max-width: 450px) {
         grid-template-columns: repeat(10, 1fr);
         grid-template-rows: repeat(10, 1fr);


### PR DESCRIPTION
## 👋 Hi there! This PR aims to address the flower grid layout on mobile. 
![Sanrio Giggle Emoji](https://github.com/user-attachments/assets/93ee5f50-2089-4f51-84b0-da3fa7a525b5)

Demo of the fix: https://drive.google.com/file/d/1p9fqOD2vQvGT50Fyy-wUFFykJBmtDS5O/view?usp=drive_link

## Changes
- moves phone layout CSS to be nested under declaration of grid class name (improves separation of concerns and IMO makes the stylings easier to update)
- adds a `.grid-container` wrapper div + styling
- updates how width is calculated for grid

## Notes
⚠️ Updating grid size beyond 10 using the import feature is broken for me, so I only tested this with 10 or smaller grids.

ℹ️ There's something that sets the flower-grid element to `max-width: 100px` that I had to overwrite using `! important` -- I suspect this must be logic within the script because I could not find where this was being set in either the html or css file. 

## 🧪 Testing
1. Pull this down locally
2. Open index.html in browser
3. At every screen size all of the flower grid should be visible, with padding along the sides

